### PR TITLE
Add requirement for silverstripe/spamprotection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "camspiers/honeypot",
     "type": "silverstripe-module",
     "require": {
+        "silverstripe/spamprotection": "~1.2.0",
         "composer/installers": "~1.0"
     }
 }


### PR DESCRIPTION
Adds a composer requirement for silverstripe/spamprotection ~1.2.0 to simplify installing via composer.