### PR TITLE
MNT: Bump Spamprotection version to support PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "heyday/silverstripe-honeypot",
     "type": "silverstripe-vendormodule",
     "require": {
-        "silverstripe/spamprotection": "~3.0.0",
+        "silverstripe/spamprotection": "^3.2",
         "composer/installers": "~1.0"
     },
     "autoload": {


### PR DESCRIPTION
Since this is somewhat a big change to the required version of spamprotection, maybe bump this version up eg. `3.1.0` whichever is appropriate